### PR TITLE
feat: Spawn new VMs inside their own network namespace

### DIFF
--- a/matchbox/Cargo.toml
+++ b/matchbox/Cargo.toml
@@ -11,6 +11,7 @@ derive_builder = "0.20.0"
 firecracker-config-rs = { path = "../firecracker-config-rs/" }
 hyper = { version = "0.14", features = ["client", "http2"] }
 hyperlocal = "0.8.0"
+nanoid = "0.4.0"
 netns-rs = "0.1.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"

--- a/matchbox/src/jailer/factory.rs
+++ b/matchbox/src/jailer/factory.rs
@@ -1,12 +1,12 @@
 use super::{
     client::FirecrackerClient, config::JailerConfigBuilder, JailedFirecracker, JailedPathResolver,
 };
-use netns_rs::NetNs;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use uuid::Uuid;
+
 
 #[derive(Clone, Debug)]
 pub struct JailedFirecrackerFactory {

--- a/matchbox/src/jailer/factory.rs
+++ b/matchbox/src/jailer/factory.rs
@@ -32,7 +32,7 @@ impl JailedFirecrackerFactory {
         }
     }
 
-    pub fn spawn_jailed_firecracker(&self, vm_id: Uuid, netns: &Path) -> JailedFirecracker {
+    pub fn spawn_jailed_firecracker(&self, vm_id: &str, netns: &Path) -> JailedFirecracker {
         let jailer_config = JailerConfigBuilder::default()
             .jailer_path(&self.jailer_path)
             .exec_file(&self.firecracker_path)
@@ -47,10 +47,10 @@ impl JailedFirecrackerFactory {
             "new-session",
             "-d",
             "-s",
-            &vm_id.to_string(),
+            &jailer_config.id,
             &jailer_config.jailer_path.to_string_lossy(),
             "--id",
-            &vm_id.to_string(),
+            &jailer_config.id,
             "--exec-file",
             &jailer_config.exec_file.to_string_lossy(),
             "--gid",

--- a/matchbox/src/jailer/mod.rs
+++ b/matchbox/src/jailer/mod.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::Child};
 
-use anyhow::Context;
+
 
 use self::client::FirecrackerClient;
 

--- a/matchbox/src/jailer/mod.rs
+++ b/matchbox/src/jailer/mod.rs
@@ -15,14 +15,6 @@ pub struct JailedFirecracker {
     pub client: FirecrackerClient,
 }
 
-impl JailedFirecracker {
-    pub fn kill(&mut self) -> anyhow::Result<()> {
-        self.process
-            .kill()
-            .context("failed to kill firecracker process")
-    }
-}
-
 #[derive(Debug)]
 pub struct JailedPathResolver {
     root_directory: PathBuf,

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use uuid::Uuid;
+
 
 static VM_ID_COUNTER: AtomicU64 = AtomicU64::new(10);
 

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -1,0 +1,36 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use uuid::Uuid;
+
+static VM_ID_COUNTER: AtomicU64 = AtomicU64::new(10);
+
+const ALPHABET: [char; 62] = [
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+    'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B',
+    'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',
+    'V', 'W', 'X', 'Y', 'Z',
+];
+
+#[derive(Debug)]
+pub struct VmIdentifier {
+    id: String,
+    counter: u64,
+}
+
+impl VmIdentifier {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn counter(&self) -> u64 {
+        self.counter
+    }
+}
+
+impl Default for VmIdentifier {
+    fn default() -> Self {
+        let id = nanoid::nanoid!(9, &ALPHABET);
+        let counter = VM_ID_COUNTER.fetch_add(2, Ordering::Relaxed);
+        Self { counter, id }
+    }
+}

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -1,7 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-
-
 static VM_ID_COUNTER: AtomicU64 = AtomicU64::new(10);
 
 const ALPHABET: [char; 62] = [
@@ -14,7 +12,7 @@ const ALPHABET: [char; 62] = [
 #[derive(Debug)]
 pub struct VmIdentifier {
     id: String,
-    counter: u64,
+    address_block: u64,
 }
 
 impl VmIdentifier {
@@ -22,15 +20,15 @@ impl VmIdentifier {
         &self.id
     }
 
-    pub fn counter(&self) -> u64 {
-        self.counter
+    pub fn address_block(&self) -> u64 {
+        self.address_block
     }
 }
 
 impl Default for VmIdentifier {
     fn default() -> Self {
         let id = nanoid::nanoid!(9, &ALPHABET);
-        let counter = VM_ID_COUNTER.fetch_add(2, Ordering::Relaxed);
-        Self { counter, id }
+        let address_block = VM_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self { address_block, id }
     }
 }

--- a/matchbox/src/sandbox/mod.rs
+++ b/matchbox/src/sandbox/mod.rs
@@ -1,15 +1,15 @@
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+
 use std::time::{Duration, Instant};
 
 use firecracker_config_rs::models::bootsource::BootSourceBuilder;
 use firecracker_config_rs::models::drive::DriveBuilder;
 use firecracker_config_rs::models::logger::{LogLevel, LoggerBuilder};
-use firecracker_config_rs::models::network_interface::{NetworkInterface, NetworkInterfaceBuilder};
+use firecracker_config_rs::models::network_interface::{NetworkInterfaceBuilder};
 use firecracker_config_rs::models::virtual_machine::{VirtualMachine, VirtualMachineBuilder};
-use uuid::Uuid;
+
 
 use crate::jailer::client::Action;
 use crate::jailer::factory::JailedFirecrackerFactory;

--- a/matchbox/src/sandbox/network/mod.rs
+++ b/matchbox/src/sandbox/network/mod.rs
@@ -1,9 +1,14 @@
 use anyhow::Context;
 use firecracker_config_rs::models::network_interface::NetworkInterface;
 use netns_rs::NetNs;
-use std::{path::Path, process::Command};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use self::commands::{IpCommand, IpTablesCommand, Table, Target};
+
+use super::id::VmIdentifier;
 
 mod commands;
 
@@ -12,68 +17,188 @@ pub const DEFAULT_CIDR_BLOCK: &str = "172.16.0.1/30";
 
 #[derive(Debug)]
 pub struct Network {
-    id: String,
-    netns: NetNs,
+    namespace_name: String,
+    address_start: u64,
 }
 
 impl Network {
-    pub fn new(id: String, interfaces: &[NetworkInterface]) -> anyhow::Result<Network> {
-        let netns = NetNs::new(&id)?;
-        let network = Self { id, netns };
+    pub fn new(id: &VmIdentifier, interfaces: &[NetworkInterface]) -> anyhow::Result<Network> {
+        // Create the network namespace
+        let _ = NetNs::new(id.id())?;
+        let network = Self {
+            namespace_name: id.id().into(),
+            address_start: id.counter(),
+        };
         network.setup(interfaces)?;
 
         Ok(network)
     }
 
-    pub fn netns_path(&self) -> &Path {
-        self.netns.path()
+    pub fn netns_path(&self) -> anyhow::Result<PathBuf> {
+        NetNs::get(&self.namespace_name)
+            .map(|ns| ns.path().to_owned())
+            .context("Failed to get network namespace")
     }
 
     fn setup(&self, interfaces: &[NetworkInterface]) -> anyhow::Result<()> {
-        self.netns
-            .run(|_| {
-                for interface in interfaces {
-                    setup_tap_device(&interface.host_dev_name).unwrap();
-                }
-            })
-            .context("failed to run commands inside network namespace")
+        let netns = NetNs::get(&self.namespace_name)?;
+        self.setup_interfaces(&netns, interfaces)?;
+        self.setup_veth_devices(&netns)?;
+
+        Ok(())
+    }
+
+    fn veth(&self) -> (String, String) {
+        let veth_name = format!("{}-veth", self.namespace_name);
+        let veth_address = format!("10.200.1.{}", self.address_start);
+        (veth_name, veth_address)
+    }
+
+    fn vpeer(&self) -> (String, String) {
+        let vpeer_name = format!("{}-vpeer", self.namespace_name);
+        let vpeer_address = format!("10.200.1.{}", self.address_start + 1);
+        (vpeer_name, vpeer_address)
+    }
+
+    fn setup_interfaces(
+        &self,
+        netns: &NetNs,
+        interfaces: &[NetworkInterface],
+    ) -> anyhow::Result<()> {
+        netns.run(|_| {
+            for interface in interfaces {
+                setup_tap_device(&interface.host_dev_name)?;
+            }
+
+            Ok::<(), anyhow::Error>(())
+        })??;
+
+        Ok(())
+    }
+
+    fn setup_veth_devices(&self, netns: &NetNs) -> anyhow::Result<()> {
+        let (veth_device_name, host_address) = self.veth();
+        let (vpeer_device_name, peer_address) = self.vpeer();
+
+        // Create the veth pair
+        IpCommand::CreateVethPair {
+            veth: veth_device_name.clone(),
+            vpeer: vpeer_device_name.clone(),
+        }
+        .output()?;
+
+        // Move vpeer into the guest network namespace
+        IpCommand::MoveDeviceToNamespace {
+            device: vpeer_device_name.clone(),
+            namespace: self.namespace_name.clone(),
+        }
+        .output()?;
+
+        // Assign veth an IP address & activate it
+        IpCommand::AddAddress {
+            cidr_block: format!("{host_address}/24"),
+            device: veth_device_name.clone(),
+        }
+        .output()?;
+
+        IpCommand::Activate {
+            device: veth_device_name.clone(),
+        }
+        .output()?;
+
+        netns.run(|_| {
+            // Assign vpeer an ip address and activate it
+            IpCommand::AddAddress {
+                cidr_block: format!("{peer_address}/24"),
+                device: vpeer_device_name.clone(),
+            }
+            .output()?;
+
+            IpCommand::Activate {
+                device: vpeer_device_name.clone(),
+            }
+            .output()?;
+
+            // Set the default route as veth (which will go through vpeer)
+            IpCommand::AddDefaultRoute {
+                address: host_address.clone(),
+            }
+            .output()?;
+
+            // Enable masquerading for all traffic leaving via vpeer
+            IpTablesCommand::EnableMasquerade {
+                source_address: None,
+                output: vpeer_device_name.clone(),
+            }
+            .output()?;
+
+            Ok::<(), anyhow::Error>(())
+        })??;
+
+        IpTablesCommand::AddRule {
+            table: Table::Forward,
+            target: Target::Accept,
+            input: veth_device_name.clone(),
+            output: HOST_INTERFACE_NAME.into(),
+        }
+        .output()?;
+        IpTablesCommand::AddRule {
+            table: Table::Forward,
+            target: Target::Accept,
+            input: HOST_INTERFACE_NAME.into(),
+            output: veth_device_name.clone(),
+        }
+        .output()?;
+
+        // Enable masquerading for all traffic coming from the peer address leaving
+        // via the host interface (ens4 in my case)
+        IpTablesCommand::EnableMasquerade {
+            source_address: Some(format!("{peer_address}/24")),
+            output: HOST_INTERFACE_NAME.into(),
+        }
+        .output()?;
+
+        Ok(())
     }
 }
 
 impl Drop for Network {
     fn drop(&mut self) {
-        let netns = NetNs::get(&self.id).unwrap();
+        let netns = NetNs::get(&self.namespace_name).unwrap();
         netns.remove().unwrap();
+        let (veth_device_name, _) = self.veth();
+
+        IpCommand::DeleteDevice {
+            device: veth_device_name,
+        }
+        .output()
+        .unwrap();
     }
 }
 
 fn setup_tap_device(device: &str) -> anyhow::Result<()> {
-    Command::from(IpCommand::CreateTapDevice {
+    IpCommand::CreateTapDevice {
         device: device.to_string(),
-    })
-    .output()
-    .unwrap();
+    }
+    .output()?;
 
-    Command::from(IpCommand::AddAddress {
+    IpCommand::AddAddress {
         cidr_block: DEFAULT_CIDR_BLOCK.into(),
         device: device.to_string(),
-    })
-    .output()
-    .unwrap();
+    }
+    .output()?;
 
-    Command::from(IpCommand::Activate {
+    IpCommand::Activate {
         device: device.to_string(),
-    })
-    .output()
-    .unwrap();
+    }
+    .output()?;
 
-    Command::from(IpTablesCommand::AddRule {
+    IpTablesCommand::AddRule {
         table: Table::Forward,
         target: Target::Accept,
         input: device.to_string(),
         output: HOST_INTERFACE_NAME.into(),
-    })
-    .output()
-    .unwrap();
+    }
+    .output()?;
     Ok(())
 }

--- a/matchbox/src/sandbox/network/mod.rs
+++ b/matchbox/src/sandbox/network/mod.rs
@@ -24,7 +24,7 @@ impl Network {
         let _ = NetNs::new(id.id())?;
         let network = Self {
             namespace_name: id.id().into(),
-            address_start: id.counter(),
+            address_start: id.address_block(),
         };
         network.setup(interfaces)?;
 

--- a/matchbox/src/sandbox/network/mod.rs
+++ b/matchbox/src/sandbox/network/mod.rs
@@ -1,10 +1,7 @@
 use anyhow::Context;
 use firecracker_config_rs::models::network_interface::NetworkInterface;
 use netns_rs::NetNs;
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::path::PathBuf;
 
 use self::commands::{IpCommand, IpTablesCommand, Table, Target};
 
@@ -50,13 +47,13 @@ impl Network {
 
     fn veth(&self) -> (String, String) {
         let veth_name = format!("{}-veth", self.namespace_name);
-        let veth_address = format!("10.200.1.{}", self.address_start);
+        let veth_address = format!("10.200.{}.10", self.address_start);
         (veth_name, veth_address)
     }
 
     fn vpeer(&self) -> (String, String) {
         let vpeer_name = format!("{}-vpeer", self.namespace_name);
-        let vpeer_address = format!("10.200.1.{}", self.address_start + 1);
+        let vpeer_address = format!("10.200.{}.11", self.address_start);
         (vpeer_name, vpeer_address)
     }
 


### PR DESCRIPTION
This will be required when spawning VMs from snapshot, but it's good to get this out of the way for now.

There's a technical limitation with the current implementation as each Sandbox is getting a full /24 block (255 ips + broadcast) but that's a problem for the future.