### PR TITLE
Feat: Reduce IPs allocated per sandbox

### DIFF
--- a/matchbox/Cargo.toml
+++ b/matchbox/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
+async-trait = "0.1.77"
 axum = "0.7.4"
 axum-macros = "0.4.1"
 derive_builder = "0.20.0"

--- a/matchbox/src/main.rs
+++ b/matchbox/src/main.rs
@@ -12,7 +12,7 @@ async fn main() -> anyhow::Result<()> {
         "/tmp/vms",
     );
     let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
-    let sandbox_factory = SandboxFactory::new(factory, sandbox_initializer);
+    let sandbox_factory = Box::new(SandboxFactory::new(factory, sandbox_initializer));
 
     let app = Application::new("0.0.0.0:3000", ApplicationState::new(sandbox_factory)).await?;
     app.run().await?;

--- a/matchbox/src/main.rs
+++ b/matchbox/src/main.rs
@@ -1,4 +1,5 @@
 use matchbox::jailer::factory::JailedFirecrackerFactory;
+use matchbox::sandbox::id::VmIdentifierFactory;
 use matchbox::sandbox::SandboxFactory;
 use matchbox::server::{Application, ApplicationState};
 
@@ -12,7 +13,11 @@ async fn main() -> anyhow::Result<()> {
         "/tmp/vms",
     );
     let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
-    let sandbox_factory = Box::new(SandboxFactory::new(factory, sandbox_initializer));
+    let sandbox_factory = Box::new(SandboxFactory::new(
+        Box::new(VmIdentifierFactory),
+        factory,
+        sandbox_initializer,
+    ));
 
     let app = Application::new("0.0.0.0:3000", ApplicationState::new(sandbox_factory)).await?;
     app.run().await?;

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -34,6 +34,12 @@ pub struct VmIdentifier {
 }
 
 impl VmIdentifier {
+    pub fn new(id: String, address_block: u64) -> VmIdentifier {
+        Self {
+            id,
+            address_block: AddressBlock::from(address_block),
+        }
+    }
     pub fn id(&self) -> &str {
         &self.id
     }
@@ -47,8 +53,7 @@ impl Default for VmIdentifier {
     fn default() -> Self {
         let id = nanoid::nanoid!(9, &ALPHABET);
         let address_block = rand::thread_rng().gen_range(0..=MAX_NETWORK_START_BLOCK);
-        let address_block = AddressBlock::from(address_block);
-        Self { address_block, id }
+        Self::new(id, address_block)
     }
 }
 
@@ -65,7 +70,7 @@ pub struct AddressBlock {
 impl From<u64> for AddressBlock {
     fn from(value: u64) -> Self {
         let block3 = value / GROUPS_IN_LAST_BLOCK;
-        let block4 = (value % GROUPS_IN_LAST_BLOCK) * 4;
+        let block4 = (value % GROUPS_IN_LAST_BLOCK) * 4 + 1;
 
         Self {
             base_address: format!("10.200.{block3}"),

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -1,9 +1,24 @@
+use std::fmt::Debug;
+
 use rand::Rng;
 
 const MAX_NETWORK_START_BLOCK: u64 = 15299;
 // since we assign 4 ips per address block, 60 * 4 = 240, leaving the last 15
 // ips open.
 const GROUPS_IN_LAST_BLOCK: u64 = 60;
+
+pub trait ProvideIdentifier: Debug + Send + Sync {
+    fn provide_identifier(&self) -> VmIdentifier;
+}
+
+#[derive(Debug)]
+pub struct VmIdentifierFactory;
+
+impl ProvideIdentifier for VmIdentifierFactory {
+    fn provide_identifier(&self) -> VmIdentifier {
+        VmIdentifier::default()
+    }
+}
 
 const ALPHABET: [char; 62] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -124,6 +124,6 @@ mod tests {
             "base address should be different after we hit the last group in a block"
         );
 
-        assert!(block2.starting_ip == 0)
+        assert!(block2.starting_ip == 1)
     }
 }

--- a/matchbox/src/sandbox/id.rs
+++ b/matchbox/src/sandbox/id.rs
@@ -1,5 +1,9 @@
 use rand::Rng;
 
+const MAX_NETWORK_START_BLOCK: u64 = 15299;
+// since we assign 4 ips per address block, 60 * 4 = 240, leaving the last 15
+// ips open.
+const GROUPS_IN_LAST_BLOCK: u64 = 60;
 
 const ALPHABET: [char; 62] = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
@@ -11,7 +15,7 @@ const ALPHABET: [char; 62] = [
 #[derive(Debug)]
 pub struct VmIdentifier {
     id: String,
-    address_block: u64,
+    address_block: AddressBlock,
 }
 
 impl VmIdentifier {
@@ -19,16 +23,87 @@ impl VmIdentifier {
         &self.id
     }
 
-    pub fn address_block(&self) -> u64 {
-        self.address_block
+    pub fn address_block(&self) -> &AddressBlock {
+        &self.address_block
     }
 }
 
 impl Default for VmIdentifier {
     fn default() -> Self {
         let id = nanoid::nanoid!(9, &ALPHABET);
-        let address_block: u8 = rand::thread_rng().gen();
-        let address_block = address_block.into();
+        let address_block = rand::thread_rng().gen_range(0..=MAX_NETWORK_START_BLOCK);
+        let address_block = AddressBlock::from(address_block);
         Self { address_block, id }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AddressBlock {
+    base_address: String,
+    starting_ip: u64,
+}
+
+/// Computes an address block from a number. We give each network 4 ip
+/// addresses. The first one is the veth device and the second one is the vpeer
+/// device. The third ip is the NAT'ed ip for the microvm. The fourth IP is
+/// empty for now, maybe we'll find a use for it later.
+impl From<u64> for AddressBlock {
+    fn from(value: u64) -> Self {
+        let block3 = value / GROUPS_IN_LAST_BLOCK;
+        let block4 = (value % GROUPS_IN_LAST_BLOCK) * 4;
+
+        Self {
+            base_address: format!("10.200.{block3}"),
+            starting_ip: block4,
+        }
+    }
+}
+
+impl AddressBlock {
+    pub fn get_ip(&self, index: impl Into<u64>) -> String {
+        format!("{}.{}", self.base_address, self.starting_ip + index.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sandbox::id::GROUPS_IN_LAST_BLOCK;
+
+    use super::{AddressBlock, MAX_NETWORK_START_BLOCK};
+
+    #[test]
+    fn test_no_panics_for_network_range() {
+        for block in 0..=MAX_NETWORK_START_BLOCK {
+            let _ = AddressBlock::from(block);
+        }
+    }
+
+    #[test]
+    fn next_door_neighbors() {
+        let block1 = AddressBlock::from(0);
+        let block2 = AddressBlock::from(1);
+
+        assert_eq!(
+            block1.base_address, block2.base_address,
+            "address block 0 & 1 should have the same base address"
+        );
+        assert_eq!(
+            block1.starting_ip + 4,
+            block2.starting_ip,
+            "next door neighbor blocks should be separated by 4"
+        );
+    }
+
+    #[test]
+    fn wrap_around_blocks() {
+        let block1 = AddressBlock::from(GROUPS_IN_LAST_BLOCK - 1);
+        let block2 = AddressBlock::from(GROUPS_IN_LAST_BLOCK);
+
+        assert_ne!(
+            block1.base_address, block2.base_address,
+            "base address should be different after we hit the last group in a block"
+        );
+
+        assert!(block2.starting_ip == 0)
     }
 }

--- a/matchbox/src/sandbox/mod.rs
+++ b/matchbox/src/sandbox/mod.rs
@@ -1,8 +1,10 @@
 use std::fs::OpenOptions;
+
 use std::path::PathBuf;
 use std::process::Command;
 
 use std::time::{Duration, Instant};
+
 
 use firecracker_config_rs::models::bootsource::BootSourceBuilder;
 use firecracker_config_rs::models::drive::DriveBuilder;
@@ -69,6 +71,18 @@ impl Drop for Sandbox {
         let root_directory = self.path_resolver().resolve("/");
         let vm_directory = root_directory.parent().unwrap();
         std::fs::remove_dir_all(vm_directory).unwrap();
+    }
+}
+
+#[async_trait::async_trait]
+pub trait ProvideSandbox {
+    async fn provide_sandbox(&self) -> anyhow::Result<Sandbox>;
+}
+
+#[async_trait::async_trait]
+impl ProvideSandbox for SandboxFactory {
+    async fn provide_sandbox(&self) -> anyhow::Result<Sandbox> {
+        self.spawn_sandbox().await
     }
 }
 

--- a/matchbox/src/server/mod.rs
+++ b/matchbox/src/server/mod.rs
@@ -10,7 +10,7 @@ use tokio::{
     sync::RwLock,
 };
 
-use crate::sandbox::{Sandbox, SandboxFactory};
+use crate::sandbox::{ProvideSandbox, Sandbox};
 
 pub mod routes;
 
@@ -18,12 +18,12 @@ pub mod routes;
 pub struct ApplicationState(Arc<ApplicationStateInner>);
 
 pub struct ApplicationStateInner {
-    sandbox_factory: SandboxFactory,
+    sandbox_factory: Box<dyn ProvideSandbox + Send + Sync>,
     sandboxes: RwLock<HashMap<String, Sandbox>>,
 }
 
 impl ApplicationState {
-    pub fn new(sandbox_factory: SandboxFactory) -> Self {
+    pub fn new(sandbox_factory: Box<dyn ProvideSandbox + Send + Sync>) -> Self {
         Self(Arc::new(ApplicationStateInner {
             sandbox_factory,
             sandboxes: Default::default(),
@@ -34,7 +34,7 @@ impl ApplicationState {
         &self.0.sandboxes
     }
 
-    pub fn sandbox_factory(&self) -> &SandboxFactory {
+    pub fn sandbox_factory(&self) -> &Box<dyn ProvideSandbox + Send + Sync> {
         &self.0.sandbox_factory
     }
 }

--- a/matchbox/src/server/routes.rs
+++ b/matchbox/src/server/routes.rs
@@ -43,7 +43,7 @@ pub async fn create_sandbox(
     State(state): State<ApplicationState>,
 ) -> ApiResult<SandboxDetailResponse> {
     let factory = state.sandbox_factory();
-    let mut sandbox = factory.spawn_sandbox().await?;
+    let mut sandbox = factory.provide_sandbox().await?;
     sandbox.start().await?;
     let id = sandbox.id().to_string();
     {

--- a/matchbox/tests/microvm_tests.rs
+++ b/matchbox/tests/microvm_tests.rs
@@ -18,7 +18,7 @@ async fn test_spawning_a_uvm() {
         "/tmp/vms",
     );
     let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
-    let factory = SandboxFactory::new(factory, sandbox_initializer);
+    let factory = Box::new(SandboxFactory::new(factory, sandbox_initializer));
 
     let mut sandbox = factory
         .spawn_sandbox()

--- a/matchbox/tests/microvm_tests.rs
+++ b/matchbox/tests/microvm_tests.rs
@@ -1,8 +1,14 @@
-use std::time::Duration;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use matchbox::{
     jailer::factory::JailedFirecrackerFactory,
-    sandbox::{id::VmIdentifierFactory, SandboxFactory, SandboxInitializer},
+    sandbox::{
+        id::{ProvideIdentifier, VmIdentifier, VmIdentifierFactory},
+        SandboxFactory, SandboxInitializer,
+    },
 };
 
 use crate::common::{ping, wait_until};
@@ -20,6 +26,42 @@ async fn test_spawning_a_uvm() {
     let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
     let factory = Box::new(SandboxFactory::new(
         Box::new(VmIdentifierFactory),
+        factory,
+        sandbox_initializer,
+    ));
+
+    let mut sandbox = factory
+        .spawn_sandbox()
+        .await
+        .expect("failed to create sandbox");
+    sandbox.start().await.expect("failed to start sandbox");
+
+    let uvm_ip = sandbox.network().microvm_ip();
+    println!("Connecting to IP {uvm_ip}");
+    wait_until(Duration::from_secs(10), || ping(&uvm_ip)).expect("failed to ping microvm");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_spawning_next_door_vms() {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    #[derive(Debug)]
+    struct MockIdentifierFactory;
+    impl ProvideIdentifier for MockIdentifierFactory {
+        fn provide_identifier(&self) -> VmIdentifier {
+            let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+            VmIdentifier::new(id.to_string(), id)
+        }
+    }
+    let factory = JailedFirecrackerFactory::new(
+        "/usr/local/bin/jailer",
+        "/usr/local/bin/firecracker",
+        "/tmp/vms",
+    );
+    let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
+
+    let factory = Box::new(SandboxFactory::new(
+        Box::new(MockIdentifierFactory),
         factory,
         sandbox_initializer,
     ));

--- a/matchbox/tests/microvm_tests.rs
+++ b/matchbox/tests/microvm_tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use matchbox::{
     jailer::factory::JailedFirecrackerFactory,
-    sandbox::{SandboxFactory, SandboxInitializer},
+    sandbox::{id::VmIdentifierFactory, SandboxFactory, SandboxInitializer},
 };
 
 use crate::common::{ping, wait_until};
@@ -18,7 +18,11 @@ async fn test_spawning_a_uvm() {
         "/tmp/vms",
     );
     let sandbox_initializer = SandboxInitializer::new("/tmp/rootfs.ext4", "/tmp/kernel.bin");
-    let factory = Box::new(SandboxFactory::new(factory, sandbox_initializer));
+    let factory = Box::new(SandboxFactory::new(
+        Box::new(VmIdentifierFactory),
+        factory,
+        sandbox_initializer,
+    ));
 
     let mut sandbox = factory
         .spawn_sandbox()


### PR DESCRIPTION
By doing some math we can scope each sandbox down to 4 IP addresses (for now).

1. The veth device
2. the vpeer device
3. the uvm ip

I had to make some other changes converting existing factories to trait & providing box trait objects to allow hooking in mocks where necessary